### PR TITLE
Fix the homebrew formula

### DIFF
--- a/Formula/govc.rb
+++ b/Formula/govc.rb
@@ -1,11 +1,12 @@
 class Govc < Formula
   desc "govc is a vSphere CLI built on top of govmomi."
   homepage "https://github.com/vmware/govmomi/blob/master/govc/README.md"
-  url "https://github.com/vmware/govmomi/releases/download/v0.18.0/govc_darwin_amd64.tar.gz"
-  version "0.18.0"
-  sha256 "d1aec35ca15587361c1b3faa159662c5af96be5c0d0de00aaacdf1b8dc1c860b"
+  url "https://github.com/vmware/govmomi/releases/download/v0.19.0/govc_darwin_amd64.gz"
+  version "0.19.0"
+  sha256 "9b67f43580cdd731ff1b963e6767248e8bbdb523c29fb97d54210574ff6e085a"
 
   def install
+    mv "govc_darwin_amd64", "govc"
     bin.install "govc"
   end
 


### PR DESCRIPTION
The upstream project changed how the packaging is done. It's now a
single gzipped binary instead of a gzipped tarball.

In order to accomodate this change, the formula needs to move the
gunzipped binary from `govc_darwin_amd64` to `govc`.

While here, bump the govc version from 0.18 to 0.19.

This change fixes Issue #2.